### PR TITLE
Force diffuse reflection to 1 in Clay Render

### DIFF
--- a/io/yaf_material.py
+++ b/io/yaf_material.py
@@ -352,6 +352,7 @@ class yafMaterial:
         bCol = mat.diffuse_color
         mirCol = mat.mirror_color
         bSpecr = mat.specular_reflect
+        bDiffRefl = mat.diffuse_reflect
         bTransp = mat.transparency
         bTransl = mat.translucency
         bTransmit = mat.transmit_filter
@@ -361,6 +362,7 @@ class yafMaterial:
             bCol = scene.gs_clay_col
             bSpecr = 0.0
             bEmit = 0.0
+            bDiffRefl = 1.0
             if not scene.gs_clay_render_keep_transparency:
                 bTransp = 0.0
                 bTransl = 0.0
@@ -442,7 +444,7 @@ class yafMaterial:
         yi.paramsSetColor("color", bCol[0], bCol[1], bCol[2])
         yi.paramsSetFloat("transparency", bTransp)
         yi.paramsSetFloat("translucency", bTransl)
-        yi.paramsSetFloat("diffuse_reflect", mat.diffuse_reflect)
+        yi.paramsSetFloat("diffuse_reflect", bDiffRefl)
         yi.paramsSetFloat("emit", bEmit)
         yi.paramsSetFloat("transmit_filter", bTransmit)
 


### PR DESCRIPTION
In my previous new Clay Material the original diffuse reflection parameter was used during the Clay Render. Now, I'm forcing it to 1.0 so all diffuse materials in render have the same reflectivity

 Changes to be committed:
    modified:   io/yaf_material.py
