### PR TITLE
Changes in Blend material properties

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -90,6 +90,14 @@ def load_handler(dummy):
             # converts old files, where propertie yaf_tex_type wasn't defined
             print("Load Handler: Convert Yafaray texture \"{0}\" with texture type: \"{1}\" to \"{2}\"".format(tex.name, tex.yaf_tex_type, tex.type))
             tex.yaf_tex_type = tex.type
+    for mat in bpy.data.materials:
+        if mat is not None:
+            # from old scenes, convert old blend material Enum properties into the new string properties
+            if mat.mat_type == "blend":
+                if not mat.is_property_set("material1name") or not mat.material1name:
+                    mat.material1name = mat.material1
+                if not mat.is_property_set("material2name") or not mat.material2name:
+                    mat.material2name = mat.material2
     # convert image output file type setting from blender to yafaray's file type setting on file load, so that both are the same...
     if bpy.context.scene.render.image_settings.file_format is not bpy.context.scene.img_output:
         bpy.context.scene.img_output = bpy.context.scene.render.image_settings.file_format

--- a/io/yaf_export.py
+++ b/io/yaf_export.py
@@ -79,11 +79,18 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
         # First export the textures of the materials type 'blend'
         for mat_slot in [m for m in obj.material_slots if m.material is not None]:
             if mat_slot.material.mat_type == 'blend':
+                blendmat_error = False
                 try:
-                    mat1 = bpy.data.materials[mat_slot.material.material1]
-                    mat2 = bpy.data.materials[mat_slot.material.material2]
+                    mat1 = bpy.data.materials[mat_slot.material.material1name]
                 except:
-                    self.yi.printWarning("Exporter: Problem with blend material {0}. Could not find one of the two blended materials".format(mat_slot.material.name))
+                    self.yi.printWarning("Exporter: Problem with blend material:\"{0}\". Could not find the first material:\"{1}\"".format(mat_slot.material.name,mat_slot.material.material1name))
+                    blendmat_error = True
+                try:
+                    mat2 = bpy.data.materials[mat_slot.material.material2name]
+                except:
+                    self.yi.printWarning("Exporter: Problem with blend material:\"{0}\". Could not find the second material:\"{1}\"".format(mat_slot.material.name,mat_slot.material.material2name))
+                    blendmat_error = True
+                if blendmat_error:
                     continue
                 for bm in [mat1, mat2]:
                     for blendtex in [bt for bt in bm.texture_slots if (bt and bt.texture and bt.use)]:
@@ -180,15 +187,21 @@ class YafaRayRenderEngine(bpy.types.RenderEngine):
                 self.yaf_object.writeObject(obj)
 
     def handleBlendMat(self, mat):
+            blendmat_error = False
             try:
-                mat1 = bpy.data.materials[mat.material1]
-                mat2 = bpy.data.materials[mat.material2]
+                mat1 = bpy.data.materials[mat.material1name]
             except:
-                self.yi.printWarning("Exporter: Problem with blend material {0}. Could not find one of the two blended materials".format(mat.name))
-                return
+                self.yi.printWarning("Exporter: Problem with blend material:\"{0}\". Could not find the first material:\"{1}\"".format(mat.name,mat.material1name))
+                blendmat_error = True
+            try:
+                mat2 = bpy.data.materials[mat.material2name]
+            except:
+                self.yi.printWarning("Exporter: Problem with blend material:\"{0}\". Could not find the second material:\"{1}\"".format(mat.name,mat.material2name))
+                blendmat_error = True
+            if blendmat_error:
+                    return
             if mat1.name == mat2.name:
-                self.yi.printWarning("Exporter: Problem with blend material {0}. {1} and {2} to blend are the same materials".format(mat.name, mat1.name, mat2.name))
-                return
+                self.yi.printWarning("Exporter: Problem with blend material \"{0}\". \"{1}\" and \"{2}\" to blend are the same materials".format(mat.name, mat1.name, mat2.name))
 
             if mat1.mat_type == 'blend':
                 self.handleBlendMat(mat1)

--- a/io/yaf_material.py
+++ b/io/yaf_material.py
@@ -441,10 +441,10 @@ class yafMaterial:
         yi = self.yi
         yi.paramsClearAll()
 
-        yi.printInfo("Exporter: Blend material with: [" + mat.material1 + "] [" + mat.material2 + "]")
+        yi.printInfo("Exporter: Blend material with: [" + mat.material1name + "] [" + mat.material2name + "]")
         yi.paramsSetString("type", "blend_mat")
-        yi.paramsSetString("material1", self.namehash(bpy.data.materials[mat.material1]))
-        yi.paramsSetString("material2", self.namehash(bpy.data.materials[mat.material2]))
+        yi.paramsSetString("material1", self.namehash(bpy.data.materials[mat.material1name]))
+        yi.paramsSetString("material2", self.namehash(bpy.data.materials[mat.material2name]))
 
         i = 0
 

--- a/prop/yaf_material.py
+++ b/prop/yaf_material.py
@@ -27,14 +27,14 @@ from bpy.props import (FloatProperty,
 
 Material = bpy.types.Material
 
-
+# This code is irrelevant after the change in the blend material to convert it from EnumProperty to StringProperty. I'm keeping this as a reference in case a better solution can be found for the blend material component materials references
 def items_mat1(self, context):
     a = []
     for mat in [m for m in bpy.data.materials if m.name not in self.name]:
         a.append((mat.name, mat.name, "First blend material"))
     return(a)
 
-
+# This code is irrelevant after the change in the blend material to convert it from EnumProperty to StringProperty. I'm keeping this as a reference in case a better solution can be found for the blend material component materials references
 def items_mat2(self, context):
     a = []
     for mat in [m for m in bpy.data.materials if m.name not in self.name]:
@@ -267,6 +267,7 @@ def register():
         description="",
         default=False)
 
+    #Deprecated blend material component Enum references, only to keep compatibility with old scenes
     Material.material1 = EnumProperty(
         name="Material one",
         description="First blend material",
@@ -276,6 +277,17 @@ def register():
         name="Material two",
         description="Second blend material",
         items=items_mat2)
+
+    #New blend material component String references, when opening old scenes it should copy the old Enum Property materials to the new String Properties
+    Material.material1name = StringProperty(
+        name="Material one",
+        description="First blend material")
+        #,        get=get_blend_mat1_old_scenes)
+
+    Material.material2name = StringProperty(
+        name="Material two",
+        description="Second blend material")
+        #,        get=get_blend_mat2_old_scenes)
 
 
 def unregister():
@@ -311,3 +323,5 @@ def unregister():
     del Material.coated
     del Material.material1
     del Material.material2
+    del Material.material1name
+    del Material.material2name

--- a/ui/properties_yaf_material.py
+++ b/ui/properties_yaf_material.py
@@ -323,14 +323,25 @@ class YAF_PT_blend_(MaterialTypePanel, Panel):
 
         box = layout.box()
         box.label(text="Choose the two materials you wish to blend.")
+
+        #old blend material Enum properties - deprecated
+        #split = box.split()
+        #col = split.column()
+        #col.label(text="Material one:")
+        #col.prop(yaf_mat, "material1", text="")
+
+        #col = split.column()
+        #col.label(text="Material two:")
+        #col.prop(yaf_mat, "material2", text="")
+
         split = box.split()
         col = split.column()
         col.label(text="Material one:")
-        col.prop(yaf_mat, "material1", text="")
+        col.prop(yaf_mat, "material1name", text="")
 
         col = split.column()
         col.label(text="Material two:")
-        col.prop(yaf_mat, "material2", text="")
+        col.prop(yaf_mat, "material2name", text="")
 
 
 


### PR DESCRIPTION
WARNING: This change breaks backwards compatibility

In the blend material, the component materials (material1 and material2) are defined as Enum properties. This causes that if somebody removes or adds a new material, the enum property does not point to the same material as before, causing unexpected changes in the Blend material components.

Unfortunately due to Blender API limitations, I don't know any way to set a consistent link between a material to another, so I've replaced the Enum properties by String properties. I've added code to convert old scenes "Enum" properties to the new "String" properties automatically.

The advantages of this solution are:
- Creating and deleting materials will not affect the existing Blend materials components.

However, there are disadvantages too, but due to Blender API limitations I cannot think in a better way (for now):
- No more dropdown menus for selecting the blend material components. You have to write down the material names.
- If you rename one of the component materials, the blend material will no longer work.

I still believe this is better than the previous blend behavior. Renaming a material that's used for a blend material would be expected to cause problems.

To mitigate this, I've made the Logging more explicit. Now, if a blend material component is not found, it will tell you what's the problematic blend material and which component (material1 or material2) cannot be found, and what is the name of the component material that cannot be found.

 Changes to be committed:
    modified:   **init**.py
    modified:   io/yaf_export.py
    modified:   io/yaf_material.py
    modified:   prop/yaf_material.py
    modified:   ui/properties_yaf_material.py
