### PR TITLE
Add Shadow Bias and Min Ray Dist advanced parameters

### DIFF
--- a/io/yaf_scene.py
+++ b/io/yaf_scene.py
@@ -128,3 +128,8 @@ def exportRenderSettings(yi, scene):
         yi.paramsSetInt("threads", scene.gs_threads)
 
     yi.paramsSetString("background_name", "world_background")
+
+    yi.paramsSetBool("adv_auto_shadow_bias_enabled", scene.adv_auto_shadow_bias_enabled)
+    yi.paramsSetFloat("adv_shadow_bias_value", scene.adv_shadow_bias_value)
+    yi.paramsSetBool("adv_auto_min_raydist_enabled", scene.adv_auto_min_raydist_enabled)
+    yi.paramsSetFloat("adv_min_raydist_value", scene.adv_min_raydist_value)

--- a/prop/yaf_scene.py
+++ b/prop/yaf_scene.py
@@ -126,6 +126,26 @@ def register():
         description="Materials refract the background as transparent",
         default=True)
 
+    Scene.adv_auto_shadow_bias_enabled = BoolProperty(
+        name="Shadow Bias Automatic",
+        description="Shadow Bias Automatic Calculation (recommended). Disable ONLY if artifacts or black dots due to bad self-shadowing, otherwise LEAVE THIS ENABLED FOR NORMAL SCENES",
+        default=True)
+
+    Scene.adv_shadow_bias_value = FloatProperty(
+        name="Shadow Bias Factor",
+        description="Shadow Bias (default 0.0005). Change ONLY if artifacts or black dots due to bad self-shadowing. Increasing this value can led to artifacts and incorrect renders.",
+        min=0.00000001, max=10000, default=0.0005)
+
+    Scene.adv_auto_min_raydist_enabled = BoolProperty(
+        name="Min Ray Dist Automatic",
+        description="Min Ray Dist Automatic Calculation (recommended), based on the Shadow Bias factor. Disable ONLY if artifacts or light leaks due to bad ray intersections, otherwise LEAVE THIS ENABLED FOR NORMAL SCENES",
+        default=True)
+
+    Scene.adv_min_raydist_value = FloatProperty(
+        name="Min Ray Dist Factor",
+        description="Min Ray Dist (default 0.00005). Change ONLY if artifacts or light leaks due to bad ray intersections. Increasing this value can led to artifacts and incorrect renders.",
+        min=0.00000001, max=10000, default=0.00005)
+
     Scene.gs_custom_string = StringProperty(
         name="Custom string",
         description="Custom string will be added to the info bar, "
@@ -413,6 +433,10 @@ def unregister():
     Scene.gs_draw_params
     Scene.bg_transp
     Scene.bg_transp_refract
+    Scene.adv_auto_shadow_bias_enabled
+    Scene.adv_shadow_bias_value
+    Scene.adv_auto_min_raydist_enabled
+    Scene.adv_min_raydist_value
     Scene.gs_custom_string
     Scene.gs_premult
     Scene.gs_transp_shad

--- a/ui/properties_yaf_render.py
+++ b/ui/properties_yaf_render.py
@@ -165,6 +165,30 @@ class YAF_PT_convert(RenderButtonsPanel, Panel):
         layout.column().operator("data.convert_yafaray_properties", text="Convert data from 2.4x")
 
 
+class YAF_PT_advanced(RenderButtonsPanel, Panel):
+    bl_label = "Advanced Settings - only for experts"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        scene = context.scene
+        layout = self.layout
+        split = layout.split()
+        col = split.column()
+        col.prop(scene, "adv_auto_shadow_bias_enabled")
+        if not scene.adv_auto_shadow_bias_enabled:
+            col = split.column()
+            sub = col.column()
+            sub.prop(scene, "adv_shadow_bias_value")
+
+        split = layout.split()
+        col = split.column()
+        col.prop(scene, "adv_auto_min_raydist_enabled")
+        if not scene.adv_auto_min_raydist_enabled:
+            col = split.column()
+            sub = col.column()
+            sub.prop(scene, "adv_min_raydist_value")
+
+
 if __name__ == "__main__":  # only for live edit.
     import bpy
     bpy.utils.register_module(__name__)


### PR DESCRIPTION
Although the new Automatic Shadow Bias and Min Ray Dist factors calculation introduced in the v0.1.99-beta2 improves the self shadowing artifacts in certain scenes, there are still certain scenes that could suffer self shadow problems. Also, the automatic calculation could introduce new artifacts in certain cases and scenes.

Creating a better algorithm to avoid self-shadow problems could be very time consuming, introduce new possible issues and artifacts and even increasing the memory usage and/or CPU usage.

Therefore, I'll go for a "hybrid" solution. By default, the Shadow Bias and Min Ray Dist factors will be automatically calculated, to keep the YafaRay spirit of "making things easy for the users". However, this modification introduces now new "advanced" parameters, so expert users could disable the automatic calculation and set manual Shadow Bias Factor and/or Min Ray Dist Factor.

The advantages of doing this:
- Avoiding new calculation algorithms that would affect everything and perhaps introduce new issues and potentially increasing CPU/RAM usage.
- For normal users the automatic calculation should be enough in most cases, making YafaRay easy enough to use.
- For expert users when encountering issues with self shadow or light leaking, they could fine tune these factors to achieve the desired results, even in scenes with strange meshes or special requirements.
- Being able to manually set these factors would also help with:
  - Terminator problems: "blocky" terminators in low-poly smooth meshes should be solved by subdividing the surfaces more, but if that's not possible, adjusting these factors could help.
  - Photon leaking: in some cases, photon leaking could happen depending on the scene and the requirements for the rendered result. Adjusting manually the Min Ray Dist could help solving those issues.
  - Any artifacts that could be caused by the automatic calculation could be solved by disabling it and setting the factor manually.

So, I believe this way, we keep YafaRay easy to use and, at the same time, we provide additional control for special fine tuning.

We will have a more complete now, as we can do any of the following:
- Have both Shadow Bias and Min Ray Dist calculated automatically (new behavior introduced in v0.1.99-beta2)
- Disable Shadow Bias Automatic calculation, setting a fixed factor of 0.0005. This would emulate the original YafaRay behavior previous to v0.1.99-beta2, where the Shadow Bias was 0.0005 and the Min Ray Dist was 0.00005.
- Disable Shadow Bias Automatic and/or Min Ray Dist Automatic and set different values. This would allow a new functionality that could be used (carefully) to fine tune the render of a specially difficult scene, where light leaks and/or shadow artifacts appear.

I also believe this solution is justified, especially when other ray tracers (even VRay) have similar factors available for the users.

 Changes to be committed:
    modified:   io/yaf_scene.py
    modified:   prop/yaf_scene.py
    modified:   ui/properties_yaf_render.py
