### PR TITLE
New parameter - enable/disable light

### DIFF
--- a/io/yaf_light.py
+++ b/io/yaf_light.py
@@ -107,6 +107,7 @@ class yafLight:
             yi.paramsSetString("type", "light_mat")
             self.lightMat = self.yi.createMaterial(name)
             self.yi.paramsClearAll()
+            #yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         if lampType == "point":
             yi.paramsSetString("type", "pointlight")
@@ -117,6 +118,7 @@ class yafLight:
                 yi.paramsSetString("type", "spherelight")
                 yi.paramsSetInt("samples", lamp.yaf_samples)
                 yi.paramsSetFloat("radius", lamp.yaf_sphere_radius)
+                yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         elif lampType == "spot":
             if self.preview and name == "Lamp.002":
@@ -135,12 +137,14 @@ class yafLight:
             yi.paramsSetFloat("shadowFuzzyness", lamp.shadow_fuzzyness)
             yi.paramsSetBool("photon_only", lamp.photon_only)
             yi.paramsSetInt("samples", lamp.yaf_samples)
+            yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         elif lampType == "sun":
             yi.paramsSetString("type", "sunlight")
             yi.paramsSetInt("samples", lamp.yaf_samples)
             yi.paramsSetFloat("angle", lamp.angle)
             yi.paramsSetPoint("direction", direct[0], direct[1], direct[2])
+            yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         elif lampType == "directional":
             yi.paramsSetString("type", "directional")
@@ -149,6 +153,7 @@ class yafLight:
             if not lamp.infinite:
                 yi.paramsSetFloat("radius", lamp.shadow_soft_size)
                 yi.paramsSetPoint("from", pos[0], pos[1], pos[2])
+            yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         elif lampType == "ies":
             yi.paramsSetString("type", "ieslight")
@@ -160,6 +165,7 @@ class yafLight:
             yi.paramsSetString("file", ies_file)
             yi.paramsSetInt("samples", lamp.yaf_samples)
             yi.paramsSetBool("soft_shadows", lamp.ies_soft_shadows)
+            yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         elif lampType == "area":
             sizeX = lamp.size
@@ -203,6 +209,7 @@ class yafLight:
             yi.paramsSetPoint("corner", point[0], point[1], point[2])
             yi.paramsSetPoint("point1", corner1[0], corner1[1], corner1[2])
             yi.paramsSetPoint("point2", corner3[0], corner3[1], corner3[2])
+            yi.paramsSetBool("light_enabled", lamp.light_enabled)
 
         if lampType not in {"sun", "directional"}:
             # "from" is not used for sunlight and infinite directional light
@@ -215,6 +222,7 @@ class yafLight:
 
         yi.paramsSetColor("color", color[0], color[1], color[2])
         yi.paramsSetFloat("power", power)
+        yi.paramsSetBool("light_enabled", lamp.light_enabled)
         yi.createLight(name)
 
         return True

--- a/prop/yaf_light.py
+++ b/prop/yaf_light.py
@@ -135,6 +135,10 @@ def register():
         description="Show distance, clip start and clip end settings for spot lamp in 3D view",
         default=False, update=set_shadow_method)
 
+    Lamp.light_enabled = BoolProperty(
+        name="Light enabled",
+        description="Enable/Disable light",
+        default=True)
 
 def unregister():
     del Lamp.lamp_type
@@ -151,3 +155,4 @@ def unregister():
     del Lamp.ies_file
     del Lamp.yaf_samples
     del Lamp.yaf_show_dist_clip
+    del Lamp.light_enabled

--- a/ui/properties_yaf_light.py
+++ b/ui/properties_yaf_light.py
@@ -52,6 +52,7 @@ class YAF_PT_lamp(DataButtonsPanel, Panel):
         lamp = context.lamp
 
         layout.prop(lamp, "lamp_type", expand=True)
+        layout.prop(lamp, "light_enabled")
 
         if lamp.lamp_type == "area":
             layout.prop(lamp, "color")


### PR DESCRIPTION
As requested in http://yafaray.org/node/661 a new parameter "Light enabled" has been added to be able to individually enable/disable light sources.

 Changes to be committed:
    modified:   io/yaf_light.py
    modified:   prop/yaf_light.py
    modified:   ui/properties_yaf_light.py
