### PR TITLE
More advanced material visibility and shadow control

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Yafaray 0.1.99-beta4 (2015-06-20) David Bluecame experimental exporter for Blender 2.75 RC:
+Yafaray 0.1.99-beta4c (2015-07-29) David Bluecame experimental exporter for Blender 2.75 RC:
 ** THIS BUILD CONTAINS EXPERIMENTAL CHANGES AND FEATURES - DO NOT USE FOR PRODUCTION SCENES **
 
 Unofficial build for XXXX (XX bits) by David Bluecame

--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ bl_info = {
               "Paulo Gomes (tuga3d), Michele Castigliego (subcomandante),"
               "Bert Buchholz, Rodrigo Placencia (DarkTide),"
               "Alexander Smirnov (Exvion), Olaf Arnold (olaf), David Bluecame",
-    "version": (0, 1, 99, 'Experimental beta4'),
+    "version": (0, 1, 99, 'Experimental beta4c'),
     "blender": (2, 7, 5),
     "location": "Info Header > Engine dropdown menu",
     "wiki_url": "http://www.yafaray.org/community/forum",

--- a/io/yaf_light.py
+++ b/io/yaf_light.py
@@ -119,6 +119,7 @@ class yafLight:
                 yi.paramsSetInt("samples", lamp.yaf_samples)
                 yi.paramsSetFloat("radius", lamp.yaf_sphere_radius)
                 yi.paramsSetBool("light_enabled", lamp.light_enabled)
+                yi.paramsSetBool("cast_shadows", lamp.cast_shadows)
 
         elif lampType == "spot":
             if self.preview and name == "Lamp.002":
@@ -138,6 +139,7 @@ class yafLight:
             yi.paramsSetBool("photon_only", lamp.photon_only)
             yi.paramsSetInt("samples", lamp.yaf_samples)
             yi.paramsSetBool("light_enabled", lamp.light_enabled)
+            yi.paramsSetBool("cast_shadows", lamp.cast_shadows)            
 
         elif lampType == "sun":
             yi.paramsSetString("type", "sunlight")
@@ -145,6 +147,7 @@ class yafLight:
             yi.paramsSetFloat("angle", lamp.angle)
             yi.paramsSetPoint("direction", direct[0], direct[1], direct[2])
             yi.paramsSetBool("light_enabled", lamp.light_enabled)
+            yi.paramsSetBool("cast_shadows", lamp.cast_shadows)
 
         elif lampType == "directional":
             yi.paramsSetString("type", "directional")
@@ -154,6 +157,7 @@ class yafLight:
                 yi.paramsSetFloat("radius", lamp.shadow_soft_size)
                 yi.paramsSetPoint("from", pos[0], pos[1], pos[2])
             yi.paramsSetBool("light_enabled", lamp.light_enabled)
+            yi.paramsSetBool("cast_shadows", lamp.cast_shadows)
 
         elif lampType == "ies":
             yi.paramsSetString("type", "ieslight")
@@ -166,6 +170,7 @@ class yafLight:
             yi.paramsSetInt("samples", lamp.yaf_samples)
             yi.paramsSetBool("soft_shadows", lamp.ies_soft_shadows)
             yi.paramsSetBool("light_enabled", lamp.light_enabled)
+            yi.paramsSetBool("cast_shadows", lamp.cast_shadows)
 
         elif lampType == "area":
             sizeX = lamp.size
@@ -210,6 +215,7 @@ class yafLight:
             yi.paramsSetPoint("point1", corner1[0], corner1[1], corner1[2])
             yi.paramsSetPoint("point2", corner3[0], corner3[1], corner3[2])
             yi.paramsSetBool("light_enabled", lamp.light_enabled)
+            yi.paramsSetBool("cast_shadows", lamp.cast_shadows)
 
         if lampType not in {"sun", "directional"}:
             # "from" is not used for sunlight and infinite directional light
@@ -223,6 +229,7 @@ class yafLight:
         yi.paramsSetColor("color", color[0], color[1], color[2])
         yi.paramsSetFloat("power", power)
         yi.paramsSetBool("light_enabled", lamp.light_enabled)
+        yi.paramsSetBool("cast_shadows", lamp.cast_shadows)
         yi.createLight(name)
 
         return True

--- a/io/yaf_material.py
+++ b/io/yaf_material.py
@@ -235,7 +235,7 @@ class yafMaterial:
         yi.paramsSetFloat("absorption_dist", mat.absorption_dist)
         yi.paramsSetFloat("dispersion_power", mat.dispersion_power)
         yi.paramsSetBool("fake_shadows", mat.fake_shadows)
-        yi.paramsSetBool("cast_shadows", mat.cast_shadows)
+        yi.paramsSetString("visibility", mat.visibility)
 
         mcolRoot = ''
         # fcolRoot = '' /* UNUSED */
@@ -315,7 +315,7 @@ class yafMaterial:
         yi.paramsSetFloat("exp_u", mat.exp_u)
         yi.paramsSetFloat("exp_v", mat.exp_v)
         yi.paramsSetFloat("specular_reflect", bSpecr)
-        yi.paramsSetBool("cast_shadows", mat.cast_shadows)
+        yi.paramsSetString("visibility", mat.visibility)
 
         diffRoot = ''
         # mcolRoot = ''  /* UNUSED */
@@ -547,7 +547,7 @@ class yafMaterial:
         yi.paramsSetColor("mirror_color", mirCol[0], mirCol[1], mirCol[2])
         yi.paramsSetBool("fresnel_effect", mat.fresnel_effect)
         yi.paramsSetFloat("IOR", mat.IOR_reflection)  # added IOR for reflection
-        yi.paramsSetBool("cast_shadows", mat.cast_shadows)
+        yi.paramsSetString("visibility", mat.visibility)
 
         if scene.gs_clay_render and not mat.clay_exclude:
              if scene.gs_clay_oren_nayar:
@@ -597,7 +597,7 @@ class yafMaterial:
         else:
             yi.paramsSetFloat("blend_value", mat.blend_value)
 
-        yi.paramsSetBool("cast_shadows", mat.cast_shadows)
+        yi.paramsSetString("visibility", mat.visibility)
 
         return yi.createMaterial(self.namehash(mat))
 

--- a/prop/yaf_light.py
+++ b/prop/yaf_light.py
@@ -139,6 +139,11 @@ def register():
         name="Light enabled",
         description="Enable/Disable light",
         default=True)
+        
+    Lamp.cast_shadows = BoolProperty(
+        name="Cast shadows",
+        description="Enable casting shadows. This is the normal and expected behavior. Disable it only for special cases!",
+        default=True)
 
 def unregister():
     del Lamp.lamp_type
@@ -156,3 +161,4 @@ def unregister():
     del Lamp.yaf_samples
     del Lamp.yaf_show_dist_clip
     del Lamp.light_enabled
+    del Lamp.cast_shadows

--- a/prop/yaf_material.py
+++ b/prop/yaf_material.py
@@ -289,10 +289,16 @@ def register():
         description="Second blend material")
         #,        get=get_blend_mat2_old_scenes)
 
-    Material.cast_shadows = BoolProperty(
-        name="Cast shadows",
-        description="Enable casting shadows. This is the normal and expected behavior. Disable it only for special cases!",
-        default=True)
+    Material.visibility = EnumProperty(
+        name="Visibility",
+        items=(
+            ('invisible', "Invisible", "Totally invisible"),
+            ('shadow_only', "Shadows only", "Invisible but casting shadows"),
+            ('no_shadows', "No shadows", "Visible but not casting shadows"),
+            ('normal', "Normal", "Normal visibility - visible casting shadows"),
+            
+        ),
+        default='normal')
 
 def unregister():
     del Material.mat_type
@@ -329,4 +335,4 @@ def unregister():
     del Material.material2
     del Material.material1name
     del Material.material2name
-    del Material.cast_shadows
+    del Material.visibility

--- a/ui/properties_yaf_light.py
+++ b/ui/properties_yaf_light.py
@@ -162,6 +162,19 @@ class YAF_PT_spot(DataButtonsPanel, Panel):
             col.label(text="")
             col.prop(lamp, "shadow_buffer_clip_end", text=" Clip End")
 
+class YAF_PT_lamp_advanced(DataButtonsPanel, Panel):
+    bl_label = "Advanced settings"
+    bl_options = {'DEFAULT_CLOSED'}
+    COMPAT_ENGINES = {'YAFA_RENDER'}
+    
+    def draw(self, context):
+        layout = self.layout
+        lamp = context.lamp
+
+        split = layout.split()
+        col = split.column()
+        layout.row().prop(lamp, "cast_shadows")
+
 
 if __name__ == "__main__":  # only for live edit.
     import bpy

--- a/ui/properties_yaf_material.py
+++ b/ui/properties_yaf_material.py
@@ -196,18 +196,6 @@ class YAF_PT_shinydiffuse_specular(MaterialTypePanel, Panel):
         sub.prop(yaf_mat, "IOR_reflection", slider=True)
         layout.row().prop(yaf_mat, "specular_reflect", slider=True)
         
-class YAF_PT_shinydiffuse_advanced(MaterialTypePanel, Panel):
-    bl_label = "Advanced settings"
-    bl_options = {'DEFAULT_CLOSED'}
-    material_type = 'shinydiffusemat'
-
-    def draw(self, context):
-        layout = self.layout
-        yaf_mat = active_node_mat(context.material)
-
-        split = layout.split()
-        col = split.column()
-        layout.row().prop(yaf_mat, "cast_shadows")
 
 class YAF_PT_glossy_diffuse(MaterialTypePanel, Panel):
     bl_label = "Diffuse reflection"
@@ -270,19 +258,6 @@ class YAF_PT_glossy_specular(MaterialTypePanel, Panel):
             col.label()
             layout.row().prop(yaf_mat, "specular_reflect", slider=True)
 
-class YAF_PT_glossy_advanced(MaterialTypePanel, Panel):
-    bl_label = "Advanced settings"
-    bl_options = {'DEFAULT_CLOSED'}
-    material_type = 'glossy', 'coated_glossy'
-
-    def draw(self, context):
-        layout = self.layout
-        yaf_mat = active_node_mat(context.material)
-
-        split = layout.split()
-        col = split.column()
-        layout.row().prop(yaf_mat, "cast_shadows")
-
 
 class YAF_PT_glass_real(MaterialTypePanel, Panel):
     bl_label = "Real glass settings"
@@ -331,19 +306,6 @@ class YAF_PT_glass_fake(MaterialTypePanel, Panel):
         layout.row().prop(yaf_mat, "glass_transmit", slider=True)
         layout.row().prop(yaf_mat, "fake_shadows")
 
-class YAF_PT_glass_advanced(MaterialTypePanel, Panel):
-    bl_label = "Advanced settings"
-    bl_options = {'DEFAULT_CLOSED'}
-    material_type = 'glass', 'rough_glass'
-
-    def draw(self, context):
-        layout = self.layout
-        yaf_mat = active_node_mat(context.material)
-
-        split = layout.split()
-        col = split.column()
-        layout.row().prop(yaf_mat, "cast_shadows")
-
 
 class YAF_PT_blend_(MaterialTypePanel, Panel):
     bl_label = "Blend material settings"
@@ -382,18 +344,18 @@ class YAF_PT_blend_(MaterialTypePanel, Panel):
         col.label(text="Material two:")
         col.prop(yaf_mat, "material2name", text="")
 
-class YAF_PT_blend_advanced(MaterialTypePanel, Panel):
+
+class YAF_PT_advanced(MaterialButtonsPanel, Panel):
     bl_label = "Advanced settings"
     bl_options = {'DEFAULT_CLOSED'}
-    material_type = 'blend'
-
+    
     def draw(self, context):
         layout = self.layout
         yaf_mat = active_node_mat(context.material)
 
         split = layout.split()
         col = split.column()
-        layout.row().prop(yaf_mat, "cast_shadows")
+        layout.row().prop(yaf_mat, "visibility")
 
 
 if __name__ == "__main__":  # only for live edit.


### PR DESCRIPTION
I've added a parameter to control which lights cast shadows and which ones do not.

Also, I've removed the recently added cast_shadow parameter and replaced it by a "visibility" parameter (enum type) so we can control the material visibility and shadow at the same time. The visibility option (in the material advanced settings) will have these possible values (per-material):

'normal' (default): Normal - Normal visibility - visible casting shadows.
'no_shadows': No shadows - visible but not casting shadows.
'shadow_only': Shadows only - invisible but casting shadows.
'invisible': Invisible: totally invisible material.

 Changes to be committed:
    modified:   README
    modified:   **init**.py
    modified:   io/yaf_light.py
    modified:   io/yaf_material.py
    modified:   prop/yaf_light.py
    modified:   prop/yaf_material.py
    modified:   ui/properties_yaf_light.py
    modified:   ui/properties_yaf_material.py
