### PR TITLE
Fix for Camera panels appearing in LuxRender

### DIFF
--- a/ui/properties_yaf_camera.py
+++ b/ui/properties_yaf_camera.py
@@ -27,6 +27,7 @@ CameraButtonsPanel.COMPAT_ENGINES = {'YAFA_RENDER'}
 
 class YAF_PT_lens(CameraButtonsPanel, Panel):
     bl_label = "Lens"
+    COMPAT_ENGINES = {'YAFA_RENDER'}
 
     def draw(self, context):
         layout = self.layout
@@ -81,6 +82,7 @@ class YAF_PT_lens(CameraButtonsPanel, Panel):
 
 class YAF_PT_camera(CameraButtonsPanel, Panel):
     bl_label = "Camera"
+    COMPAT_ENGINES = {'YAFA_RENDER'}
 
     def draw(self, context):
         layout = self.layout
@@ -110,6 +112,7 @@ class YAF_PT_camera(CameraButtonsPanel, Panel):
 
 class YAF_PT_camera_display(CameraButtonsPanel, Panel):
     bl_label = "Display"
+    COMPAT_ENGINES = {'YAFA_RENDER'}
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
When LuxRender and YafaRay are enabled in Blender, sometimes the YafaRay camera panels appear among the LuxRender panels.

The problem is explained here:
http://www.luxrender.net/forum/viewtopic.php?f=16&t=12405&start=20

I believe that's because the property COMPAT_ENGINES is set to the base class which is also set by LuxRender. In my opinion we should set this property individually for each of the YafaRay classes and not relying in the base class.

I also believe we should review all YafaRay UI python files to make sure this kind of undesired interference with other renderers does not happen with other YafaRay classes, maybe also putting this property to each YafaRay individual class?

 Changes to be committed:
    modified:   ui/properties_yaf_camera.py
